### PR TITLE
Fix: Unable to find data/phil_meta.xml when running pyoaiharvest.py w…

### DIFF
--- a/pyoaiharvest.py
+++ b/pyoaiharvest.py
@@ -1,3 +1,4 @@
+import os
 import time
 import re
 import xml.dom.pulldom
@@ -92,6 +93,11 @@ if __name__ == "__main__":
         serverString = "http://" + serverString
 
     print("Writing records to %s from archive %s" % (outFileName, serverString))
+    os.makedirs('data', exist_ok=True)
+    with open(outFileName, "w") as file:
+        file.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+        file.write("<metadata>\n")
+        file.write("</metadata>\n")
 
     ofile = codecs.lookup("utf-8")[-1](open(outFileName, "wb"))
 


### PR DESCRIPTION
Hey just saw this quick bug where when I run this command

```
python pyoaiharvest.py -l https://philarchive.org/oai.pl -o data/phil_meta.xml
```

Then I get this error of:

```
FileNotFoundError: [Errno 2] No such file or directory: 'data/phil_meta.xml
```

So, just thought to provide a quick fix for this issue #2
Thanks